### PR TITLE
Enforcing consistent formatting of Jest tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/eslint-config",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1233,6 +1233,11 @@
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
       }
+    },
+    "eslint-plugin-jest-formatting": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-1.2.0.tgz",
+      "integrity": "sha512-EqsbDByAtdQa5vEhJFUFMqTW7fghN0Qhb8oulM7R3j9+9xRuMsQKCPjWvCIxpWhl3SJJmlxBC25o1pUXiBHaAw=="
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^23.1.1",
+    "eslint-plugin-jest-formatting": "^1.2.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.1.1",

--- a/testing.js
+++ b/testing.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:jest/recommended', 'plugin:jest/style'],
+  extends: ['plugin:jest/recommended', 'plugin:jest/style', 'plugin:jest-formatting/recommended'],
   plugins: ['jest'],
   env: {
     'jest/globals': true,

--- a/testing.js
+++ b/testing.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   rules: {
     'jest/consistent-test-it': 'warn',
-    'jest/expect-expect': 'warn',
+    'jest/expect-expect': 'error',
     'jest/no-disabled-tests': 'off',
     'jest/no-duplicate-hooks': 'warn',
     'jest/no-expect-resolves': 'warn',


### PR DESCRIPTION
This loads in the [eslint-plugin-jest-formatting](https://npm.im/eslint-plugin-jest-formatting) package to enforce a consistent set of rules around how Jest tests should be styled.

This also resolves an issue where the `jest/expect-expect` rule was set to `warn` instead of `error`.