### PR TITLE
feat: including our standard prettier config so it can be shared

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/index.js
+++ b/index.js
@@ -34,7 +34,14 @@ module.exports = {
 
     'prefer-destructuring': 'off',
 
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+      'error',
+      {
+        printWidth: 120,
+        singleQuote: true,
+        trailingComma: 'es5',
+      },
+    ],
 
     'sonarjs/cognitive-complexity': 'off',
     'sonarjs/no-collapsible-if': 'off',


### PR DESCRIPTION
Having this in our core ESLint config will allow us to stop requiring `.pretteirrc` files in every repository.