### PR TITLE
feat: exporting our prettier config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Create a `.eslintrc` file with the following contents:
 * `@readme/eslint-config/react`
 * `@readme/eslint-config/testing`
 
+### Prettier
+Included in this is our shared Prettier config. You can use it in your application by adding the following to your `package.json`:
+
+```json
+"prettier": "@readme/eslint-config/prettier"
+```
+
 ## Contributing
 To assist in cleaner commit logs and a better changelog, all commit messages must be formatted against the https://commitlint.js.org/ standards.
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const prettierConfig = require('./prettier');
+
 module.exports = {
   extends: [
     'airbnb-base',
@@ -16,11 +18,7 @@ module.exports = {
     'eslint-comments/no-unused-disable': 'error',
 
     'func-names': 'off',
-
-    'import/default': 'off',
-    'import/named': 'off', // @fixme Disabling this for now, but there are some weird callouts with it.
     'import/order': 'off',
-
     'no-constructor-return': 'error',
     'no-dupe-else-if': 'error',
     'no-else-return': ['error', { allowElseIf: true }],
@@ -34,21 +32,12 @@ module.exports = {
 
     'prefer-destructuring': 'off',
 
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 120,
-        singleQuote: true,
-        trailingComma: 'es5',
-      },
-    ],
+    'prettier/prettier': ['error', prettierConfig],
 
     'sonarjs/cognitive-complexity': 'off',
     'sonarjs/no-collapsible-if': 'off',
     'sonarjs/no-duplicate-string': 'off',
     'sonarjs/no-duplicated-branches': 'off',
-    'sonarjs/no-identical-functions': 'off', // @todo We should fix these.
-    'sonarjs/prefer-immediate-return': 'off', // @todo We should fix these.
 
     'unicorn/catch-error-name': ['error', { caughtErrorsIgnorePattern: '^(error|err|e)$' }],
     // "unicorn/consistent-function-scoping": "error", // Maybe?
@@ -56,15 +45,11 @@ module.exports = {
     'unicorn/error-message': 'error',
     'unicorn/new-for-builtins': 'error',
     'unicorn/no-array-instanceof': 'error',
-    // "unicorn/no-for-loop": "error", // Maybe?
     'no-nested-ternary': 'off', // Disabled in favor of `unicorn/no-nested-ternary` which has better nesting detection.
     'unicorn/no-nested-ternary': 'error',
     'unicorn/no-unreadable-array-destructuring': 'error',
     'unicorn/no-unsafe-regex': 'error',
     'unicorn/no-unused-properties': 'error',
-    // "unicorn/prefer-includes": "error", // Maybe?
-    // "unicorn/prefer-query-selector": "error", // Maybe?
-    'unicorn/prefer-starts-ends-with': 'off', // @todo We should resolve these.
     'unicorn/prefer-type-error': 'error',
     'unicorn/throw-new-error': 'error',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -913,8 +913,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "parse-json": {
@@ -2085,9 +2084,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "path-exists": {
@@ -2993,12 +2992,20 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "modify-values": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/eslint-config",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/prettier.js
+++ b/prettier.js
@@ -1,0 +1,5 @@
+module.exports = {
+  arrowParens: 'avoid',
+  printWidth: 120,
+  singleQuote: true,
+};


### PR DESCRIPTION
## 🧰 What's being changed?

* [ ] Exporting our Prettier config to a new target: `@readme/eslint-config/prettier`
* [ ] Removing some defaults from our base ESLint config that only apply to our main codebase. These rules should not be off by default in other projects.
