### PR TITLE
quote JS object properties consistently

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "printWidth": 120,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "quoteProps": "consistent"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "printWidth": 120,
   "singleQuote": true,
-  "trailingComma": "es5",
-  "quoteProps": "consistent"
+  "quoteProps": "consistent",
+  "trailingComma": "es5"
 }


### PR DESCRIPTION
Updates our Prettier config to address an issue where `npm test -- -u` would auto-convert unicode strings _back_ to emojis in our scripts, which caused breakage in IE11 (See: [api-explorer#e357013](https://github.com/readmeio/api-explorer/pull/687/commits/e357013dbf2a6abb3bbb4dee99263884c285069f)) Alternately, we could probably override this directly in the Explorer somehow; no opinion on which'd be better...