### PR TITLE
feat: pulling eslint-plugin-react-hooks into our react config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2508,8 +2508,30 @@
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
           "requires": {
             "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.1",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+              "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+              }
+            }
           }
         }
       }
@@ -2940,6 +2962,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "dev": true
     },
     "eslint-plugin-sonarjs": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "conventional-changelog-cli": "^2.0.28",
     "eslint": "^7.0.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^4.0.0",
     "prettier": "^2.0.2"
   },

--- a/react.js
+++ b/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:jsx-a11y/recommended', 'plugin:react/recommended'],
+  extends: ['plugin:jsx-a11y/recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended'],
   plugins: ['jsx-a11y', 'react'],
   env: {
     browser: true,


### PR DESCRIPTION
This pulls [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) into our react config to ensure that we're not violating the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html).