### PR TITLE
feat: prefer bare test and nested it

### DIFF
--- a/testing.js
+++ b/testing.js
@@ -13,7 +13,7 @@ module.exports = {
   rules: {
     'import/no-extraneous-dependencies': 'off',
 
-    'jest/consistent-test-it': 'warn',
+    'jest/consistent-test-it': ['warn', { fn: 'test', withinDescribe: 'it' }],
     'jest/expect-expect': 'error',
     'jest/no-conditional-expect': 'error',
     'jest/no-deprecated-functions': 'off',


### PR DESCRIPTION
Adapted from the plugin [docs](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/consistent-test-it.md):

```
/*eslint jest/consistent-test-it: ["error", {"fn": "test", "withinDescribe": "it"}]*/

test('foo'); // valid
describe('foo', function () {
  it('bar'); // valid
});

it('foo'); // invalid
describe('foo', function () {
  test('bar'); // invalid
});
```