### PR TITLE
chore: allow nested ternary statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
     'no-dupe-else-if': 'error',
     'no-else-return': ['error', { allowElseIf: true }],
 
-    'no-nested-ternary': 'off', // Disabled in favor of `unicorn/no-nested-ternary` which has better nesting detection.
+    'no-nested-ternary': 'off', // See also: `unicorn/no-nested-ternary`
 
     'no-restricted-imports': ['error', { paths: ['lodash'] }],
 
@@ -57,7 +57,7 @@ module.exports = {
     'unicorn/new-for-builtins': 'error',
     // 'unicorn/no-array-method-this-argument': 'error', // Maybe?
     'unicorn/no-instanceof-array': 'error',
-    'unicorn/no-nested-ternary': 'error',
+    'unicorn/no-nested-ternary': 'off', // See also: `no-nested-ternary`
     'unicorn/no-unreadable-array-destructuring': 'error',
     'unicorn/no-unsafe-regex': 'error',
     'unicorn/no-unused-properties': 'error',


### PR DESCRIPTION
## 🧰 Changes
- [x] **Turn off the `unicorn/no-nested-ternary` lint rule.**
  Nested ternary statements can provide a nice, clean pattern for writing complex if/else-if/else logic in JSX:

  ```jsx
  {isLoading ? (
    <Spinner />
  ) : !data?.length ? (
    <Flex justify="center">No results.</Flex>
  ) : (
    <Table body={data} />
  )}
  ```
  But this syntax throws a lint error in the React app! Instead, you'd be forced to write something ugly, like:
  ```jsx
  {tableIsLoading ? (
    <Spinner style={{ color: "var(--shale)" }} />
  ) : (
    (!table?.length && <Flex justify="center">No data found.</Flex>) || (
      <Table body={table || []} />
    )
  )}
  ```

## 🧬 QA & Testing
If you can write a nested ternary in your JSX without the linter throwing a fit, this worked!