### PR TITLE
feat: loosening up the npm engine requirements to easily allow npm@8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,21 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2.4.0
 
       - uses: actions/setup-node@v2.5.0
         with:
-          node-version: 14.15.1
+          node-version: ${{ matrix.node-version }}
 
-      - run: npm install -g npm@7
+      # Node 16 still ships with npm@8 so for compatibility reasons we're upping this for everything else.
+      - name: Install npm@8
+        if: matrix.node-version != '16.x'
+        run: npm install -g npm@8
+
       - run: npm ci
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,7 @@
         "husky": "^7.0.1"
       },
       "engines": {
-        "node": "^12 || ^14",
-        "npm": "^7"
+        "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
         "eslint": "^8.0.0",
@@ -1498,34 +1497,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz",
-      "integrity": "sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/visitor-keys": "5.5.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.5.0.tgz",
-      "integrity": "sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz",
@@ -1600,30 +1571,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz",
-      "integrity": "sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.5.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/acorn": {
@@ -6563,20 +6510,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz",
-      "integrity": "sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==",
-      "requires": {
-        "@typescript-eslint/types": "5.5.0",
-        "@typescript-eslint/visitor-keys": "5.5.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.5.0.tgz",
-      "integrity": "sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg=="
-    },
     "@typescript-eslint/typescript-estree": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz",
@@ -6617,22 +6550,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz",
-      "integrity": "sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==",
-      "requires": {
-        "@typescript-eslint/types": "5.5.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "url": "git@github.com:readmeio/eslint-config.git"
   },
   "engines": {
-    "node": "^12 || ^14",
-    "npm": "^7"
+    "node": "^12 || ^14 || ^16"
   },
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
## 🧰 What's being changed?

Installing this library with npm@8 generates a warning that it actually wants npm@7. Since either work, and the npm requirement is only really there for local development I'm removing it.

And in order to make sure that the library still works okay without this on Node 12 and Node 14 I'm updating our CI workflow to install npm@8 on these versions. This is unnecessary on Node 16 because Node 16 ships with npm@8 already. 

## 🧬 Testing

* [ ] Tests pass?