### PR TITLE
fix: requiring consistency of typescript record types

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -6,6 +6,7 @@ module.exports = {
     'import/resolver': 'typescript',
   },
   rules: {
+    '@typescript-eslint/consistent-indexed-object-style': 'error',
     '@typescript-eslint/consistent-type-imports': 'error',
 
     // Disable requiring return types because it's too easy to broaden them by accident.


### PR DESCRIPTION
## 🧰 What's being changed?

https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md