### PR TITLE
feat: tweaking our use of the `no-use-before-define` rule in TS

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -31,5 +31,10 @@ module.exports = {
     // The stock `no-unused-vars` ESlint rule doesn't play with TS.
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ['error'],
+
+    // The stock `no-use-before-define` ESLint rule throws errors when TS interfaces, types, and
+    // enums are used before they're defined -- eventhough in TS that's OK.
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': ['error'],
   },
 };


### PR DESCRIPTION
## 🧰 What's being changed?

Slightly tweaks our `no-use-before-define` rule usage in the TS config to allow TS types that can be used before they're defined without errors.

For example, without this rule change the following code was throwing an error on `ConfigOptions` being used before it was defined even though TS is perfectly fine with where it's located in the file.:

```ts
import Oas from 'oas';
import APICore from './src/core';
import definition from './test/__fixtures__/simple.oas.json';

export default class SDK {
  spec: Oas;
  core: APICore;
  authKeys: (number | string)[][] = [];

  constructor() {
    this.spec = Oas.init(definition);
    this.core = new APICore(this.spec, 'api/1.0.0');
  }

  config(config: ConfigOptions) {
    this.core.setConfig(config);
  }
}

interface ConfigOptions {
  /**
   * By default we parse the response based on the `Content-Type` header of the request. You can
   * disable this functionality by negating this option.
   */
  parseResponse: boolean;
}
```