### PR TITLE
chore(stylelint-config): removing `stylelint-prettier`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7313,12 +7313,6 @@
       "version": "3.1.3",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -11951,18 +11945,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -13733,22 +13715,6 @@
         "stylelint": "^16.18.0 || ^17.0.0"
       }
     },
-    "node_modules/stylelint-prettier": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-5.0.3.tgz",
-      "integrity": "sha512-B6V0oa35ekRrKZlf+6+jA+i50C4GXJ7X1PPmoCqSUoXN6BrNF6NhqqhanvkLjqw2qgvrS0wjdpeC+Tn06KN3jw==",
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "prettier": ">=3.0.0",
-        "stylelint": ">=16.0.0"
-      }
-    },
     "node_modules/stylelint-scss": {
       "version": "6.12.1",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
@@ -15327,8 +15293,7 @@
         "stylelint-config-sass-guidelines": "^13.0.0",
         "stylelint-config-standard": "^39.0.1",
         "stylelint-config-standard-scss": "^16.0.0",
-        "stylelint-order": "^8.1.1",
-        "stylelint-prettier": "^5.0.3"
+        "stylelint-order": "^8.1.1"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.2",

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -57,4 +57,3 @@ We've adopted the following list of shared configs that remain actively maintain
 - [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) - The standard shareable SCSS config for Stylelint.
 - [stylelint-config-sass-guidelines](https://github.com/bjankord/stylelint-config-sass-guidelines) - A stylelint config inspired by [sass-guidelin.es](https://sass-guidelin.es/).
 - [stylelint-config-css-modules](https://github.com/pascalduez/stylelint-config-css-modules) - CSS modules shareable config for stylelint. Tweaks stylelint rules to accept [css modules](https://github.com/css-modules/css-modules) specific syntax.
-- [stylelint-prettier/recommended](https://github.com/prettier/stylelint-prettier) - Runs Prettier as a Stylelint rule and reports differences as individual Stylelint issues.

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -27,8 +27,7 @@
     "stylelint-config-sass-guidelines": "^13.0.0",
     "stylelint-config-standard": "^39.0.1",
     "stylelint-config-standard-scss": "^16.0.0",
-    "stylelint-order": "^8.1.1",
-    "stylelint-prettier": "^5.0.3"
+    "stylelint-order": "^8.1.1"
   },
   "peerDependencies": {
     "postcss": "^8.4.12"

--- a/packages/stylelint-config/src/index.js
+++ b/packages/stylelint-config/src/index.js
@@ -11,9 +11,6 @@ module.exports = {
 
     // Support CSS modules syntax
     'stylelint-config-css-modules',
-
-    // Enable prettier formatting for SCSS/CSS
-    'stylelint-prettier/recommended',
   ],
   plugins: [
     // Enable ordering rules for content within declaration blocks.

--- a/packages/stylelint-config/test/__snapshots__/index.test.js.snap
+++ b/packages/stylelint-config/test/__snapshots__/index.test.js.snap
@@ -1,10 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`stylelint-config > prettier rules > matches snapshot with all formatting errors fixed 1`] = `
-"$prettier: 'should be single quotes';
-"
-`;
-
 exports[`stylelint-config > with an invalid file and auto-fix enabled > matches the auto-fixed snapshot 1`] = `
 "@import 'x.css';
 @import 'y.css';

--- a/packages/stylelint-config/test/index.test.js
+++ b/packages/stylelint-config/test/index.test.js
@@ -84,33 +84,4 @@ describe('stylelint-config', () => {
       expect(data.code).toContain('&:not(.one):not(.two):not(.three)');
     });
   });
-
-  describe('prettier rules', () => {
-    it('matches snapshot with all formatting errors fixed', async () => {
-      data = await stylelint.lint({
-        code: `
-$prettier: "should be single quotes";
-`,
-        config,
-        fix: true,
-      });
-      ({ warnings } = data.results[0]);
-
-      expect(data.code).toMatchSnapshot();
-    });
-
-    it('flags double quotes as an error', async () => {
-      data = await stylelint.lint({
-        code: `
-$prettier: "should be single quotes";
-`,
-        config,
-      });
-      ({ warnings } = data.results[0]);
-
-      expect(warnings).toHaveLength(2);
-      expect(warnings[0].rule).toBe('@stylistic/string-quotes');
-      expect(warnings[1].rule).toBe('prettier/prettier');
-    });
-  });
 });


### PR DESCRIPTION
## 🧰 Changes

This removes `stylelint-prettier` and all Prettier rules from our `stylelint-config` package because we've moved to using [Oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) for our formatting needs.